### PR TITLE
fix: fix ci script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
   apt:
     packages:
       - xvfb
+      - libgconf-2-4
 install:
   - export DISPLAY=':99.0'
   - Xvfb :99 -screen 0 1366x768x24 > /dev/null 2>&1 &

--- a/ci.sh
+++ b/ci.sh
@@ -6,6 +6,8 @@ npm i npm@6 -g --registry=https://registry.npm.taobao.org
 
 npm i
 
-npm run ci:travis
+npm run lint
+npm run serve &
+npm run test:antd
 
 npm run reliable


### PR DESCRIPTION
the script was removed https://github.com/app-bootstrap/web-app-bootstrap/commit/852974f0da26eceff0868acbdc40d0a1c43eb93c#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L23
but `ci.sh` is still needed for reliable integration:
https://macacajs.github.io/reliable/guide/jenkins-web.html#quick-start
also, gitlab is having issue with new ubuntu version:
https://github.com/cypress-io/cypress/issues/4069